### PR TITLE
add: data availability chart to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ for the source. You can use `cat timestamps.csv your-timestamps.csv > new-timest
 to create a new, unsorted timestamp file. To sort it, you can use
 `LC_ALL=C sort --reverse --check --unique new-timestamps.csv > timestamps.csv`.
 
+
+Also, please remember to update the data-availability graph (see below).
+
 ## Quality Assurance
 
 The dataset is run through automatic quality assurance checks in the CI. A
@@ -35,3 +38,19 @@ For this, we maintain a list of height and header timestamps in
 list might need to be updated. This can be done with the Bash script
 "qa/block-timestamps/update-block-timestamps.sh" requiring a Bitcoin Core
 instance with the REST server enabled.
+
+A data availability graph can be generated with the tool 
+`qa/data-availability/gen-mermaid.py`. This should be updated when adding a
+new data source.
+
+```mermaid
+gantt
+dateFormat x
+title data availability (not showing potential per-source holes)
+todayMarker off
+
+0xb10c memo: 1635945250000, 1666268995000
+0xB10C monitoring1: 1605513978094, 1666260553663
+0xb10c memo-old: 1562848974000, 1585739362000
+
+```

--- a/qa/data-availability/gen-mermaid.py
+++ b/qa/data-availability/gen-mermaid.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import csv
+
+ARRIVAL_TIMESTAMP_FILE = "timestamps.csv"
+
+min_max_time_per_source = dict()
+
+with open(ARRIVAL_TIMESTAMP_FILE, "r") as f:
+    reader = csv.reader(f)
+    for row in reader:
+        _, __, timestamp, source = row
+        if source not in min_max_time_per_source:
+            min_max_time_per_source[source] = {
+                "min": timestamp, "max": timestamp}
+        if timestamp < min_max_time_per_source[source]["min"]:
+            min_max_time_per_source[source]["min"] = timestamp
+        if timestamp > min_max_time_per_source[source]["max"]:
+            min_max_time_per_source[source]["max"] = timestamp
+
+    mermaid_rows = ""
+    for source in min_max_time_per_source:
+        mermaid_rows += f"{source}: {min_max_time_per_source[source]['min']}, {min_max_time_per_source[source]['max']}" + "\n"
+
+    mermaid = f"""
+```mermaid
+gantt
+dateFormat x
+title data availability (not showing potential per-source holes)
+todayMarker off
+
+{mermaid_rows}
+```"""
+    print(mermaid)


### PR DESCRIPTION
generated with `gen-mermaid.py`


```mermaid
gantt
dateFormat x
title data availability (not showing potential per-source holes)
todayMarker off
0xb10c memo: 1635945250000, 1666268995000
0xB10C monitoring1: 1605513978094, 1666260553663
0xb10c memo-old: 1562848974000, 1585739362000
```